### PR TITLE
Added request/inbox functionality. 

### DIFF
--- a/controllers/api/data_routes.js
+++ b/controllers/api/data_routes.js
@@ -1,5 +1,5 @@
 const router = require('express').Router();
-const {User,Chat,Request,Message} =require('../../models');
+const {User,Chat,Request,Message, ChatUser, Friendship} =require('../../models');
 
 //routes for user
 router.get('/user', async (req,res) =>{
@@ -194,7 +194,7 @@ router.post('/request', async (req,res) =>{
 
 router.delete('/request/:id', async (req,res) =>{
     try{
-        const requestData = await User.destroy({
+        const requestData = await Request.destroy({
             where:{
                 id:req.params.id
             }
@@ -211,5 +211,56 @@ router.delete('/request/:id', async (req,res) =>{
         res.status(500).json(err);
     }
 })
+
+// Post Route for Friendship
+router.post('/friendship', async (req, res) => {
+    const {friend1_id, friend2_id} = req.body;
+
+    if(req.body.friend1_id && req.body.friend2_id){
+        try{
+            const friendshipData = Friendship.create(req.body);
+    
+            if(!friendshipData){
+                res.status(404).json({message: 'error creating friendship'})
+            }
+            else{
+                res.status(200).json(friendshipData);
+            }
+        }
+        catch (err) {
+            console.error(err);
+            res.status(500).json(err);
+        }
+    }
+    else{
+        res.status(400).json({message: 'Bad request'});
+    };
+});
+
+
+// Post route for chatuser
+router.post('/chatuser', async (req, res) => {
+    const {user_id, chat_id} = req.body;
+
+    if(req.body.user_id && req.body.chat_id){
+        try{
+            const chatuserData = ChatUser.create(req.body);
+
+            if(!chatuserData){
+                res.status(404).json({message: 'something went wrong creating chatuser'});
+            }
+            else{
+                res.status(200).json(chatuserData);
+            };
+        }
+        catch (err) {
+            console.error(err);
+            res.status(500).json(err);
+        };
+    }
+    else{
+        res.status(400).json({message: 'bad request'});
+    };
+});
 
 module.exports = router;

--- a/controllers/pageRoutes.js
+++ b/controllers/pageRoutes.js
@@ -88,25 +88,26 @@ router.get('/inbox', withAuth, async (req, res) => {
 
         //define boolean to show whether there are requests or not
         let areThereRequests;
-
-        if(!inboxData){
+        if(inboxData.length === 0){
             areThereRequests = false;
         }
         else{
-            // simplify inbox data into something easier to use
-            const requests = inboxData.map((request) => (
-                request.get({plain:true})
-            ));
-
-            // render inbox template with specified data. 
-            res.render('inbox', {
-                loggedIn: req.session.loggedIn,
-                userId: req.session.userId,
-                areThereRequests,
-                requests
-            });
-            res.status(200);
+            areThereRequests = true;
         };
+
+         // simplify inbox data into something easier to use
+        const requests = inboxData.map((request) => (
+            request.get({plain:true})
+        ));
+
+        // render inbox template with specified data. 
+        res.render('inbox', {
+            loggedIn: req.session.loggedIn,
+            userId: req.session.userId,
+            areThereRequests,
+            requests
+        });
+        res.status(200);
     }
     catch (err) {
         console.error(err);

--- a/models/request.js
+++ b/models/request.js
@@ -28,6 +28,9 @@ Request.init(
         type: {
             type: DataTypes.STRING,
             allowNull: false
+        },
+        inviteChat_id: {
+            type: DataTypes.INTEGER,
         }
     },
     {

--- a/public/js/inbox.js
+++ b/public/js/inbox.js
@@ -1,2 +1,94 @@
-// Create functionallity to the accept and reject buttons. On accept, a post request should be made to the api db chat route, 
-//and the request should be deleted with a delete request to the api db requests route. if rejected, the request should just be deleted. 
+const userId = sessionUserId;
+const requests = sessionRequests;
+
+const requestPlace = document.querySelector('#requestPlace');
+
+console.log(requests);
+
+const deleteRequest = async (request, element) =>{
+    //Delete request from the database.
+    const deletePost = await fetch(`api/db/request/${request.id}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' }
+    });
+
+    if(deletePost.ok){
+        //Remove request element from page if deletion is success.
+        element.remove();
+    }
+    else{
+        alert('Failed to delete request');
+    }
+}
+
+const acceptRequest = async (request, element) =>{
+    //If it is a friend request, make a new friend with the data and remove the request element. 
+    if(request.type === 'friend'){
+        const author_id = request.author.id;
+
+        const postFriend = await fetch('/api/db/friendship', {
+            method: 'POST',
+            body: JSON.stringify({
+                'friend1_id':author_id ,
+                'friend2_id':userId }),
+            headers: { 'Content-Type': 'application/json' },
+          });
+      
+          if (postFriend.ok) {
+            deleteRequest(request, element);
+          } 
+          else {
+            alert('Failed to create friendship.');
+          };
+    }
+    else if(request.type === 'chat'){
+        // if it is a chat request, make a new chat user with the data and remove the request element. 
+        const invitedChat = request.inviteChat_id;
+
+        const postChatUser = await fetch('/api/db/chatuser', {
+            method: 'POST',
+            body: JSON.stringify({
+                'user_id':userId ,
+                'chat_id':invitedChat }),
+            headers: { 'Content-Type': 'application/json' },
+          });
+      
+          if (postChatUser.ok) {
+            deleteRequest(request, element);
+          } 
+          else {
+            alert('Failed to create chatuser.');
+          };
+    };
+};
+
+const createRequestElement = async (request) =>{
+    const requestBox = document.createElement('div');
+    
+    const header = document.createElement('h3');
+    if(request.type === 'friend'){
+        header.textContent = `Become friends with ${request.author.username}?`;
+    }
+    else if(request.type === 'chat'){
+        header.textContent = `Accept chat request from ${request.author.username}?`;
+    }
+
+    const acceptButton = document.createElement('button');
+    acceptButton.textContent = 'Yes';
+    acceptButton.addEventListener('click', () => acceptRequest(request, requestBox));
+
+    const rejectButton = document.createElement('button');
+    rejectButton.textContent = 'No';
+    rejectButton.addEventListener('click', () => deleteRequest(request, requestBox));
+
+    requestBox.append(header);
+    requestBox.append(acceptButton);
+    requestBox.append(rejectButton);
+    
+
+    requestPlace.append(requestBox);
+};
+
+requests.forEach(request => {
+    createRequestElement(request);
+});

--- a/public/js/userpage.js
+++ b/public/js/userpage.js
@@ -44,7 +44,8 @@ const sendRequest = async (btn) => {
           body: JSON.stringify({
             'author_id': userId,
             'recipient_id': user.id,
-            'type': 'friend'
+            'type': 'friend',
+            'inviteChat_id': 0
           }),
           headers: { 'Content-Type': 'application/json' },
         });

--- a/seeds/requestData.json
+++ b/seeds/requestData.json
@@ -2,27 +2,32 @@
     {
       "author_id": 1,
       "recipient_id": 2,
-      "type": "friend"
+      "type": "friend",
+      "inviteChat_id": 0
     },
     {
       "author_id": 1,
       "recipient_id": 14,
-      "type": "friend"
+      "type": "friend",
+      "inviteChat_id": 0
     },
     {
       "author_id": 1,
-      "recipient_id": 14,
-      "type": "chat"
+      "recipient_id": 5,
+      "type": "chat",
+      "inviteChat_id":2
     },
     {
       "author_id": 15,
-      "recipient_id": 3,
-      "type": "chat"
+      "recipient_id": 2,
+      "type": "chat",
+      "inviteChat_id":7
     },
     {
-      "author_id": 7,
-      "recipient_id": 14,
-      "type": "chat"
+      "author_id": 14,
+      "recipient_id": 15,
+      "type": "chat",
+      "inviteChat_id":8
     }
   ]
   

--- a/views/inbox.handlebars
+++ b/views/inbox.handlebars
@@ -2,13 +2,7 @@
     {{#if loggedIn}}
     <h2>Inbox</h2>
     {{#if areThereRequests}}
-    {{#each requests as |request|}}
-    <div>
-        <h3>Chat with {{request.user.username}}?</h3>
-        <button id="accept">Accept</button>
-        <button id="decline">Decline</button>
-    </div>
-    {{/each}}
+    <div id="requestPlace"></div>
     {{else}}
     <h2>Empty...</h2>
     {{/if}}
@@ -19,5 +13,12 @@
 </footer>
 
 {{#if loggedIn}}
+{{#if areThereRequests}}
+
+<script>
+    var sessionUserId = {{{userId}}};
+    var sessionRequests = {{{json requests}}};
+</script>
 <script src="/js/inbox.js"></script>
+{{/if}}
 {{/if}}


### PR DESCRIPTION
        Added two new attributes to request, type and inviteChat_id. The types are friend and chat. For every request which has its recipient_id equal to the client id, a request box is populated on the page, with a small description and two buttons to accept or reject. 
        Upon accepting, inbox.js checks the type of request. If it is a friend request, a new friendship is uploaded to the database. If it is a chat request, a new userchat is uploaded. Once either of those things are uploaded, the request is deleted from the database and the request box is removed from the screen. Upon rejecting, the request is deleted from the database and the box is removed from the page. 

       I'm not sure If I added this in the last commit but the friendship model is now a part of our settup, and it tracks which users are friends with one another. Users can see who they are friends with on their own userpage.  